### PR TITLE
Sync GitHub Actions improvements from the main repo

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -5,22 +5,38 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
+
+permissions: {}
+
 jobs:
   build:
+    # As this action runs on a schedule, only run it in the FreeTubeApp/FreeTubeApp.io repository to avoid unnecessary GitHub Actions usage/billing in forks.
+    # Still allow the workflow to be manually triggered.
+    # If a fork does need this workflow, they can change this condition in their fork to include their repository.
+    if: github.repository == 'FreeTubeApp/FreeTubeApp.io' || github.event_name == 'workflow_dispatch'
+
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@9d037c06280028c110ff61c433ad4dc7d33c3c43
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true
       - name: Create New Pull Request If Needed
         if: steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
           title: Compressed Images Nightly
           branch-suffix: timestamp

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -8,12 +8,23 @@ on:
   pull_request_target:
     types: [synchronize]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
-    runs-on: ubuntu-latest
+    name: Check for conflicts
+    runs-on: ubuntu-slim
+
+    permissions:
+      pull-requests: write
+
     steps:
       - name: check if prs are dirty
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 #v3.1.0
         with:
           dirtyLabel: "PR: merge conflicts / rebase needed"
           removeOnDirtyLabel: "PR: waiting for review"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,12 +5,14 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   sshAndDeploy:
     runs-on: ubuntu-latest
     steps:
     - name: SSH Remote and Pull Changes
-      uses: appleboy/ssh-action@v1.2.5
+      uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 #v1.2.5
       with:
         host: ${{ secrets.SERVER_IP }}
         username: ${{ secrets.SERVER_USER }}

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -3,15 +3,18 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review]
 
+permissions: {}
+
 jobs:
   triage:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+
+    runs-on: ubuntu-slim
     if: ${{ !github.event.pull_request.draft }}
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 #v7.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/pr-labeler.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,22 @@
 name: Auto Merge PR
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, auto_merge_disabled, ready_for_review]
+
+permissions: {}
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.state == 'open' &&
+      !github.event.pull_request.draft &&
+      contains(github.event.pull_request.base.ref, 'master')
+    runs-on: ubuntu-slim
 
     steps:
     - name: Auto Merge PR
-      if: contains(${{ github.event.pull_request.base.ref }}, 'master')
-      run: |
-        echo ${{ secrets.GH_TOKEN }} >> auth.txt
-        gh auth login --with-token < auth.txt
-        rm auth.txt
-        gh pr merge https://github.com/FreeTubeApp/FreeTubeApp.io/pull/${{ github.event.pull_request.number }} --auto --squash
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        PR_URL: ${{ github.event.pull_request.html_url }}
+      run: gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/remove-outdated-labels.yml
+++ b/.github/workflows/remove-outdated-labels.yml
@@ -5,57 +5,66 @@ on:
       - closed
       - converted_to_draft
       - ready_for_review
-jobs:
-  remove-merged-pr-labels:
-    name: Remove merged pull request labels
-    if: github.event.pull_request.merged
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mondeja/remove-labels-gh-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            PR: waiting for review
-            PR: WIP
-            PR: changes requested
-            PR: merge conflicts / rebase needed
-            PR/Issue: dependent
-            PR: stale
 
+permissions: {}
+
+jobs:
   remove-closed-pr-labels:
-    name: Remove closed pull request labels
-    if: github.event_name == 'pull_request_target' && (! github.event.pull_request.merged) && (github.event.action != 'converted_to_draft') && (github.event.action != 'ready_for_review')
-    runs-on: ubuntu-latest
+    name: Remove closed and merged pull request labels
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-slim
+
+    permissions:
+      pull-requests: write
+
     steps:
-      - uses: mondeja/remove-labels-gh-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            PR: waiting for review
-            PR: WIP
-            PR: changes requested
-            PR: merge conflicts / rebase needed
-            PR/Issue: dependent
-            PR: stale
+      - name: Remove labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          labels='PR: waiting for review,'
+          labels+='PR: WIP,'
+          labels+='PR: changes requested,'
+          labels+='PR: merge conflicts / rebase needed,'
+          labels+='PR/Issue: dependent,'
+          labels+='PR: stale'
+
+          gh pr edit "$PR_URL" --remove-label "$labels"
 
   remove-draft-pr-labels:
     name: Remove labels from draft pull requests
-    if: github.event_name == 'pull_request_target' && github.event.action == 'converted_to_draft'
-    runs-on: ubuntu-latest
+    if: |
+      github.event.action == 'converted_to_draft' && contains(github.event.pull_request.labels.*.name, 'PR: waiting for review')
+    runs-on: ubuntu-slim
+
+    permissions:
+      pull-requests: write
+
     steps:
-      - uses: mondeja/remove-labels-gh-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            PR: waiting for review
-            
+      - name: Remove label
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$PR_URL" --remove-label 'PR: waiting for review'
+
   remove-ready-pr-labels:
     name: Remove labels when draft pr is marked ready for review
-    if: github.event_name == 'pull_request_target' && github.event.action == 'ready_for_review'
-    runs-on: ubuntu-latest
+    if: |
+      github.event.action == 'ready_for_review' && contains(github.event.pull_request.labels.*.name, 'PR: WIP')
+    runs-on: ubuntu-slim
+
+    permissions:
+      pull-requests: write
+
     steps:
-      - uses: mondeja/remove-labels-gh-action@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            PR: WIP
+      - name: Remove label
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$PR_URL" --remove-label 'PR: WIP'


### PR DESCRIPTION
List of changes:
- Limit GITHUB_TOKEN permissions to the ones that are actually required and disable persisting credentials in the checkout action
- Pin Action versions
- Run some workflows on ubuntu-slim
- Switch the remove labels workflow to `gh pr edit --remove-label`
- Add the concurrency controls to the conflicts workflow (probably not needed in this repo but keeping for parity)
- Don't run scheduled workflows in forks by default